### PR TITLE
remove redundant 'h1' element from events index page

### DIFF
--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,6 +1,4 @@
 <%= link_to "Sign up", new_user_registration_path %>
 <%= link_to "Sign in", new_user_session_path %>
 
-<h1>First Question</h1>
-
 <%= link_to "Create Event", new_event_path %>


### PR DESCRIPTION
This was just left over from an old piece of code. Simply deleted.